### PR TITLE
Also initializes when setup is called

### DIFF
--- a/lua/dmacro.lua
+++ b/lua/dmacro.lua
@@ -39,7 +39,7 @@ local function setup(opts)
 			vim.b.prev_completion = nil
 		end,
 	})
-	vim.on_key(function(key, typed)
+	vim.on_key(function(_, typed)
 		if typed ~= '' and typed ~= nil then
 			vim.b.dmacro_history = vim.fn.extend({ typed }, vim.b.dmacro_history)
 			if string.upper(vim.fn.keytrans(typed)) ~= string.upper(dmacro_key) then

--- a/lua/dmacro.lua
+++ b/lua/dmacro.lua
@@ -32,12 +32,14 @@ local function setup(opts)
 		print('dmacro_key is undefined')
 	end
 	local this_group = vim.api.nvim_create_augroup('dmacro', {})
+	local function initialize()
+		vim.b.dmacro_history = {}
+		vim.b.prev_completion = nil
+	end
+	initialize()
 	vim.api.nvim_create_autocmd('BufWinEnter', {
 		group = this_group,
-		callback = function()
-			vim.b.dmacro_history = {}
-			vim.b.prev_completion = nil
-		end,
+		callback = initialize,
 	})
 	vim.on_key(function(_, typed)
 		if typed ~= '' and typed ~= nil then

--- a/lua/dmacro.lua
+++ b/lua/dmacro.lua
@@ -31,8 +31,8 @@ local function setup(opts)
 	if not dmacro_key then
 		print('dmacro_key is undefined')
 	end
-	local this_group = vim.api.nvim_create_augroup("dmacro", {})
-	vim.api.nvim_create_autocmd("BufWinEnter", {
+	local this_group = vim.api.nvim_create_augroup('dmacro', {})
+	vim.api.nvim_create_autocmd('BufWinEnter', {
 		group = this_group,
 		callback = function()
 			vim.b.dmacro_history = {}
@@ -40,7 +40,7 @@ local function setup(opts)
 		end,
 	})
 	vim.on_key(function(key, typed)
-		if typed ~= "" and typed ~= nil then
+		if typed ~= '' and typed ~= nil then
 			vim.b.dmacro_history = vim.fn.extend({ typed }, vim.b.dmacro_history)
 			if string.upper(vim.fn.keytrans(typed)) ~= string.upper(dmacro_key) then
 				if vim.b.prev_completion then
@@ -50,7 +50,7 @@ local function setup(opts)
 			end
 		end
 	end)
-	vim.keymap.set({ "i", "n" }, dmacro_key, function()
+	vim.keymap.set({ 'i', 'n' }, dmacro_key, function()
 		vim.b.dmacro_history = vim.list_slice(vim.b.dmacro_history, 2)
 		local completion = vim.b.prev_completion
 		completion = completion or guess_completion_1()

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,3 @@
+indent_type = "Tabs"
+indent_width = 2
+quote_style = "AutoPreferSingle"


### PR DESCRIPTION
Depending on the method of delayed startup, the buffer local variable may not be initialized by BufWinEnter and may enter the vim.on_key process. This PR solves that problem.
It also includes commits for small fixes such as mixing single and double quotes and resolving warnings for unused arguments.