### PR TITLE
fix(lua): use `vim.notify()` instead of `vim.echomsg()` in `dmacro.setup()`

### DIFF
--- a/lua/dmacro.lua
+++ b/lua/dmacro.lua
@@ -121,7 +121,7 @@ end
 
 --- Setup function for dmacro.
 function _M.setup(opts)
-	vim.echomsg("dmacro: dmacro.setup() is obsolete, use vim.keymap.set() directly.")
+	vim.notify("dmacro: dmacro.setup() is obsolete, use vim.keymap.set() directly.", vim.log.levels.WARN)
 end
 
 return _M


### PR DESCRIPTION
Unlike `:echomsg`, `vim.notify()` allows us to customize the appearance of the message.

NOTE: `vim.echomsg()` doesn't exist. If you want to use `:echomsg` in Lua, you can use `vim.cmd` like this:

```lua
vim.cmd.echomsg('"dmacro: dmacro.setup() is obsolete, use vim.keymap.set() directly."')
-- or
vim.cmd('echomsg "dmacro: dmacro.setup() is obsolete, use vim.keymap.set() directly."')
```