### PR TITLE
perf(lua): don't copy tables and reduce for loops

### DIFF
--- a/lua/dmacro.lua
+++ b/lua/dmacro.lua
@@ -70,21 +70,34 @@ function _M.guess_macro_2(keys)
   return nil
 end
 
---- Set the current state of dmacro.
--- This function sets the current keys and previous macro of dmacro in the buffer.
---- @param keys string[]?: The keys you have typed.
---- @param macro string[]?: The previous macro to be set.
-function _M.set_state(keys, macro)
-  vim.b.dmacro_keys = keys
-  vim.b.dmacro_macro = macro
-end
+do
+  --- @type table<integer, { keys: string[]?, macro: string[]? }>
+  local buf_states = {}
+  vim.api.nvim_create_autocmd('BufDelete', {
+    group = vim.api.nvim_create_augroup('Dmacro', { clear = true }),
+    callback = function(cx)
+      buf_states[cx.buf] = nil
+    end,
+  })
 
---- Get the current state of dmacro.
--- This function retrieves the current keys and previous macro of dmacro from the buffer.
---- @return string[]? keys: The keys you have typed.
---- @return string[]? macro: The previous macro to be set.
-function _M.get_state()
-  return vim.b.dmacro_keys, vim.b.dmacro_macro
+  --- Set the current state of dmacro.
+  -- This function sets the current keys and previous macro of dmacro in the buffer.
+  --- @param keys string[]?: The keys you have typed.
+  --- @param macro string[]?: The previous macro to be set.
+  function _M.set_state(keys, macro)
+    buf_states[vim.api.nvim_get_current_buf()] = { keys = keys, macro = macro }
+  end
+
+  --- Get the current state of dmacro.
+  -- This function retrieves the current keys and previous macro of dmacro from the buffer.
+  --- @return string[]? keys: The keys you have typed.
+  --- @return string[]? macro: The previous macro to be set.
+  function _M.get_state()
+    local state = buf_states[vim.api.nvim_get_current_buf()]
+    if state then
+      return state.keys, state.macro
+    end
+  end
 end
 
 --- This function is responsible for handling the dynamic macro functionality in Neovim.

--- a/lua/dmacro.lua
+++ b/lua/dmacro.lua
@@ -82,13 +82,13 @@ function _M.play_macro()
     macro = macro or _M.guess_macro_1(keys)
     if macro then
       vim.fn.feedkeys(table.concat(macro))
-      _M.set_state(vim.list_extend({ unpack(keys) }, { unpack(macro) }), macro)
+      _M.set_state(vim.list_extend(keys, macro), macro)
       return
     end
     macro = macro or _M.guess_macro_2(keys)
     if macro then
       vim.fn.feedkeys(table.concat(macro))
-      _M.set_state(vim.list_extend({ unpack(keys) }, { unpack(macro) }), nil)
+      _M.set_state(vim.list_extend(keys, macro), nil)
       return
     end
     _M.set_state(keys, macro)
@@ -116,7 +116,7 @@ function _M.record_macro(_, typed)
         end
       end
     end
-    _M.set_state(vim.list_extend({ unpack(keys or {}) }, { typed }), macro)
+    _M.set_state(vim.list_extend(keys or {}, { typed }), macro)
   end
 end
 

--- a/test/dmacro.lua
+++ b/test/dmacro.lua
@@ -1,6 +1,8 @@
 local dmacro = require('./lua/dmacro')
 
-function test(name, func)
+--- @param name string
+--- @param func fun()
+local function test(name, func)
   print('Test: ' .. name .. ' started')
   func()
   print('Test: ' .. name .. ' passed')
@@ -36,4 +38,10 @@ test('get_and_set_state', function()
   local actual_keys, actual_macro = dmacro.get_state()
   assert(vim.deep_equal(expected_keys, actual_keys))
   assert(vim.deep_equal(expected_macro, actual_macro))
+end)
+
+test('span_equal', function()
+  local keys = { 'd', 'c', 'b', 'a', 'c', 'b', 'a' }
+  assert(dmacro.span_equal(keys, 2, 5, 3))
+  assert(not dmacro.span_equal(keys, 1, 5, 3))
 end)

--- a/test/dmacro.lua
+++ b/test/dmacro.lua
@@ -36,8 +36,8 @@ test('get_and_set_state', function()
   local expected_macro = macro
   dmacro.set_state(keys, macro)
   local actual_keys, actual_macro = dmacro.get_state()
-  assert(vim.deep_equal(expected_keys, actual_keys))
-  assert(vim.deep_equal(expected_macro, actual_macro))
+  assert(expected_keys == actual_keys)
+  assert(expected_macro == actual_macro)
 end)
 
 test('span_equal', function()

--- a/test/dmacro.lua
+++ b/test/dmacro.lua
@@ -10,7 +10,7 @@ end
 
 test('guess_macro_1:ok', function()
   local keys = { 'd', 'c', 'b', 'a', 'c', 'b', 'a' }
-  local expected = { 'c', 'b', 'a' }
+  local expected = { 5, 7 } -- { 'c', 'b', 'a' }
   local actual = dmacro.guess_macro_1(keys)
   assert(vim.deep_equal(expected, actual))
 end)
@@ -24,14 +24,26 @@ end)
 
 test('guess_macro_2:ok', function()
   local keys = { 'd', 'c', 'b', 'a', 'c', 'b' }
-  local expected = { 'a' }
+  local expected = { 4, 4 } -- { 'a' }
   local actual = dmacro.guess_macro_2(keys)
   assert(vim.deep_equal(expected, actual))
 end)
 
+test('is_macro_still_valid:ok', function ()
+  local keys = { 'd', 'c', 'b', 'a', 'c', 'b', 'a' }
+  local macro = { 2, 4 }
+  assert(dmacro.has_prev_macro_suffix(macro, keys))
+end)
+
+test('is_macro_still_valid:ng', function ()
+  local keys = { 'd', 'c', 'b', 'a', 'c', 'b', 'a' }
+  local macro = { 2, 3 }
+  assert(not dmacro.has_prev_macro_suffix(macro, keys))
+end)
+
 test('get_and_set_state', function()
   local keys = { 'a', 'b', 'c', 'a', 'b', 'c', 'd' }
-  local macro = { 'a' }
+  local macro = { 1, 1 }
   local expected_keys = keys
   local expected_macro = macro
   dmacro.set_state(keys, macro)


### PR DESCRIPTION
"reduce for loop" means the internal use of `vim.list_slice` and `vim.deep_equal`.